### PR TITLE
Remove the `--first-parent` option from log list generation

### DIFF
--- a/src/Changelog.js
+++ b/src/Changelog.js
@@ -113,7 +113,7 @@ export default class Changelog {
 
   getListOfCommits() {
     var lastTag = this.getLastTag();
-    var commits = execSync("git log --first-parent --oneline " + lastTag + "..").split("\n");
+    var commits = execSync("git log --oneline " + lastTag + "..").split("\n");
     return commits;
   }
 


### PR DESCRIPTION
`--first-parent` can lose commits in a workflow with multiple merges to reach the branch where changelogs are generated.

I ran into this generating changelogs on react-server's `next` branch.  We've been merging non-breaking PRs straight to master, and periodically merging master into `next`, where we're staging a version with breaking changes.  When I run `lerna-changelog` in `next` it doesn't include changes from the PRs that were merged straight to master (without this patch).