### PR TITLE
Convert label name to lowercase before matching

### DIFF
--- a/src/Changelog.js
+++ b/src/Changelog.js
@@ -190,7 +190,7 @@ export default class Changelog {
 
       logs.forEach(function(log) {
         var labels = log.labels.map(function(label) {
-          return label.name;
+          return label.name.toLowerCase();
         });
 
         if (labels.indexOf(label.toLowerCase()) >= 0) {


### PR DESCRIPTION
Lerna Changelog didn't work with labels having uppercase letters because it converted the configured label names to lowercase, but compared them with the actual labels without lowercasing those first.

This change fixes the issue by converting both names to lowercase before comparing them.