### PR TITLE
Exclude arrow functions, classes and generator functions from being transpiled

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,10 @@
     ["env", {
       "targets": {
         "node": 4
-      }
+      },
+      "exclude": [
+        "transform-regenerator"
+      ]
     }]
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,8 @@
         "node": 4
       },
       "exclude": [
+        "transform-es2015-arrow-functions",
+        "transform-es2015-classes",
         "transform-regenerator"
       ]
     }]


### PR DESCRIPTION
These features are already supported by Node 4