### PR TITLE
configuration-error: Add missing "message" property

### DIFF
--- a/src/configuration-error.spec.ts
+++ b/src/configuration-error.spec.ts
@@ -8,4 +8,9 @@ describe("ConfigurationError", function() {
     const error = new Error('foobar');
     expect(error instanceof ConfigurationError).toEqual(false);
   });
+
+  it("`message` property equals first constructor argument", function() {
+    const error = new ConfigurationError('foobar');
+    expect(error.message).toEqual('foobar');
+  });
 });

--- a/src/configuration-error.ts
+++ b/src/configuration-error.ts
@@ -1,7 +1,9 @@
 export default class ConfigurationError {
   name = "ConfigurationError";
+  message: string;
 
   constructor(message: string) {
     Error.apply(this, arguments);
+    this.message = message;
   }
 }


### PR DESCRIPTION
Apparently extending `Error` is not enough for some reason... 🤔 