### PR TITLE
Declare Node version support (6+)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ cache:
   directories:
   - node_modules
 node_js:
-  - '7'
   - '6'
-  - '4'
+  - '8'
+  - '10'
 
 env:
   - JOB=test

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "tslint": "^5.10.0",
     "typescript": "^2.9.2"
   },
+  "engines": {
+    "node": ">=6"
+  },
   "changelog": {
     "repo": "lerna/lerna-changelog",
     "labels": {


### PR DESCRIPTION
This PR changes the supported Node versions from 4+ to 6+ since Node 4 is EOL now. This should be considered a breaking change.