### PR TITLE
CI: Remove `node_modules` from cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ git:
   depth: 10
 sudo: false
 language: node_js
-cache:
-  yarn: true
-  directories:
-  - node_modules
+
+cache: yarn
+
 node_js:
   - '6'
   - '8'


### PR DESCRIPTION
Caching the `yarn` cache should be sufficient.