### PR TITLE
Improve automatic config detection

### DIFF
--- a/src/__mocks__/changelog.ts
+++ b/src/__mocks__/changelog.ts
@@ -1,3 +1,5 @@
+import { Configuration } from "../configuration";
+
 const Changelog = require.requireActual("../changelog").default;
 
 const defaultConfig = {
@@ -11,11 +13,12 @@ const defaultConfig = {
     "Type: Documentation": ":memo: Documentation",
     "Type: Maintenance": ":house: Maintenance",
   },
+  ignoreCommitters: [],
   cacheDir: ".changelog",
 };
 
 class MockedChangelog extends Changelog {
-  private loadConfig(options: any) {
+  private loadConfig(options: Partial<Configuration>): Configuration {
     return Object.assign({}, defaultConfig, options);
   }
   private getToday() {

--- a/src/__mocks__/changelog.ts
+++ b/src/__mocks__/changelog.ts
@@ -15,8 +15,8 @@ const defaultConfig = {
 };
 
 class MockedChangelog extends Changelog {
-  private getConfig() {
-    return defaultConfig;
+  private loadConfig(options: any) {
+    return Object.assign({}, defaultConfig, options);
   }
   private getToday() {
     return "2099-01-01";

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -1,7 +1,7 @@
 const pMap = require("p-map");
 
 import progressBar from "./progress-bar";
-import * as Configuration from "./configuration";
+import { Configuration, load as loadConfig } from "./configuration";
 import findPullRequestId from "./find-pull-request-id";
 import * as Git from "./git";
 import GithubAPI, { GitHubUserResponse } from "./github-api";
@@ -16,11 +16,11 @@ interface Options {
 }
 
 export default class Changelog {
-  private config: any;
+  private readonly config: Configuration;
   private github: GithubAPI;
   private renderer: MarkdownRenderer;
 
-  constructor(options: any = {}) {
+  constructor(options: Partial<Configuration> = {}) {
     this.config = this.loadConfig(options);
     this.github = new GithubAPI(this.config);
     this.renderer = new MarkdownRenderer({
@@ -38,8 +38,8 @@ export default class Changelog {
     return this.renderer.renderMarkdown(releases);
   }
 
-  private loadConfig(options: any) {
-    return Configuration.load(options);
+  private loadConfig(options: Partial<Configuration>): Configuration {
+    return loadConfig(options);
   }
 
   private async getCommitInfos(from: string, to: string): Promise<CommitInfo[]> {
@@ -119,10 +119,6 @@ export default class Changelog {
   }
 
   private ignoreCommitter(login: string): boolean {
-    if (!this.config.ignoreCommitters) {
-      return false;
-    }
-
     return this.config.ignoreCommitters.some((c: string) => c === login || login.indexOf(c) > -1);
   }
 

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -21,7 +21,7 @@ export default class Changelog {
   private renderer: MarkdownRenderer;
 
   constructor(options: Options = {}) {
-    this.config = Object.assign(this.getConfig(), options);
+    this.config = this.loadConfig(options);
     this.github = new GithubAPI(this.config);
     this.renderer = new MarkdownRenderer({
       categories: Object.keys(this.config.labels).map(key => this.config.labels[key]),
@@ -35,8 +35,8 @@ export default class Changelog {
     return this.renderer.renderMarkdown(releases);
   }
 
-  private getConfig() {
-    return Configuration.fromGitRoot(process.cwd());
+  private loadConfig(options: Options) {
+    return Configuration.load(options);
   }
 
   private async getCommitInfos(): Promise<CommitInfo[]> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ export async function run() {
   };
 
   try {
-    let result = await new Changelog(options).createMarkdown();
+    let result = await new Changelog().createMarkdown(options);
     console.log(result);
   } catch (e) {
     if (e instanceof ConfigurationError) {

--- a/src/configuration.spec.ts
+++ b/src/configuration.spec.ts
@@ -2,29 +2,10 @@ const os = require("os");
 const fs = require("fs-extra");
 const path = require("path");
 
-import { findRepoFromPkg, fromGitRoot, fromPath } from "./configuration";
+import { findRepoFromPkg, fromPath } from "./configuration";
 import ConfigurationError from "./configuration-error";
 
 describe("Configuration", function() {
-  describe("fromGitRoot", function() {
-    it("reads the configuration from 'lerna.json'", function() {
-      const rootPath = path.resolve(`${__dirname}/..`);
-      const result = fromGitRoot(path.join(rootPath, "src"));
-      expect(result).toEqual({
-        repo: "lerna/lerna-changelog",
-        labels: {
-          breaking: ":boom: Breaking Change",
-          enhancement: ":rocket: Enhancement",
-          bug: ":bug: Bug Fix",
-          documentation: ":memo: Documentation",
-          internal: ":house: Internal",
-        },
-        cacheDir: ".changelog",
-        rootPath,
-      });
-    });
-  });
-
   describe("fromPath", function() {
     const tmpDir = `${os.tmpDir()}/changelog-test`;
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -39,8 +39,11 @@ export function fromPath(rootPath: string, options: Partial<Configuration> = {})
 
   if (!labels) {
     labels = {
+      breaking: ":boom: Breaking Change",
       enhancement: ":rocket: Enhancement",
       bug: ":bug: Bug Fix",
+      documentation: ":memo: Documentation",
+      internal: ":house: Internal",
     };
   }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -5,6 +5,10 @@ const normalize = require("normalize-git-url");
 
 import ConfigurationError from "./configuration-error";
 
+export function load(options: any) {
+  return Object.assign(fromGitRoot(process.cwd()), options);
+}
+
 export function fromGitRoot(cwd: string): any {
   const rootPath = execa.sync("git", ["rev-parse", "--show-toplevel"], { cwd }).stdout;
   return fromPath(rootPath);


### PR DESCRIPTION
Previously the default config was loaded in an "all or nothing" fashion, only when there was no config found in the `package.json` or `lerna.json` files. With this PR we load the config from those files first (or default to `{}`) and afterwards fill in the missing pieces individually.