### PR TITLE
Add `@` sign in front of contributor login

### DIFF
--- a/src/__snapshots__/markdown-renderer.spec.ts.snap
+++ b/src/__snapshots__/markdown-renderer.spec.ts.snap
@@ -56,6 +56,6 @@ exports[`MarkdownRenderer renderContributionList renders a list of contributions
 
 exports[`MarkdownRenderer renderContributorList renders a list of GitHub users 1`] = `
 "#### Committers: 2
-- Tobias Bieniek ([Turbo87](https://github.com/Turbo87))
-- [hzoo](https://github.com/hzoo)"
+- Tobias Bieniek ([@Turbo87](https://github.com/Turbo87))
+- [@hzoo](https://github.com/hzoo)"
 `;

--- a/src/functional/__snapshots__/markdown-full.spec.ts.snap
+++ b/src/functional/__snapshots__/markdown-full.spec.ts.snap
@@ -9,7 +9,7 @@ exports[`createMarkdown multiple tags outputs correct changelog 1`] = `
   * [#1](https://github.com/lerna/lerna-changelog/pull/1) feat: May the force be with you. ([@luke](https://github.com/luke))
 
 #### Committers: 1
-- Luke Skywalker ([luke](https://github.com/luke))
+- Luke Skywalker ([@luke](https://github.com/luke))
 
 
 ## empire-strikes-back@5.0.0 (1977-05-25)
@@ -19,7 +19,7 @@ exports[`createMarkdown multiple tags outputs correct changelog 1`] = `
   * [#1](https://github.com/lerna/lerna-changelog/pull/1) feat: May the force be with you. ([@luke](https://github.com/luke))
 
 #### Committers: 1
-- Luke Skywalker ([luke](https://github.com/luke))
+- Luke Skywalker ([@luke](https://github.com/luke))
 
 
 ## return-of-the-jedi@6.0.0 (1977-05-25)
@@ -29,7 +29,7 @@ exports[`createMarkdown multiple tags outputs correct changelog 1`] = `
   * [#1](https://github.com/lerna/lerna-changelog/pull/1) feat: May the force be with you. ([@luke](https://github.com/luke))
 
 #### Committers: 1
-- Luke Skywalker ([luke](https://github.com/luke))"
+- Luke Skywalker ([@luke](https://github.com/luke))"
 `;
 
 exports[`createMarkdown single project outputs correct changelog 1`] = `
@@ -43,7 +43,7 @@ exports[`createMarkdown single project outputs correct changelog 1`] = `
 * [#7](https://github.com/lerna/lerna-changelog/pull/7) feat: that is not how the Force works!. ([@han-solo](https://github.com/han-solo))
 
 #### Committers: 1
-- Han Solo ([han-solo](https://github.com/han-solo))
+- Han Solo ([@han-solo](https://github.com/han-solo))
 
 
 ## v6.0.0 (1983-05-25)
@@ -61,9 +61,9 @@ exports[`createMarkdown single project outputs correct changelog 1`] = `
 * [#4](https://github.com/lerna/lerna-changelog/pull/4) fix: RRRAARRWHHGWWR. ([@chewbacca](https://github.com/chewbacca))
 
 #### Committers: 3
-- Chwebacca ([chewbacca](https://github.com/chewbacca))
-- Darth Vader ([vader](https://github.com/vader))
-- Princess Leia Organa ([princess-leia](https://github.com/princess-leia))
+- Chwebacca ([@chewbacca](https://github.com/chewbacca))
+- Darth Vader ([@vader](https://github.com/vader))
+- Princess Leia Organa ([@princess-leia](https://github.com/princess-leia))
 
 
 ## v5.0.0 (1980-05-17)
@@ -75,8 +75,8 @@ exports[`createMarkdown single project outputs correct changelog 1`] = `
 * [#3](https://github.com/lerna/lerna-changelog/pull/3) fix: Get me the rebels base!. ([@vader](https://github.com/vader))
 
 #### Committers: 2
-- Darth Vader ([vader](https://github.com/vader))
-- Governor Tarkin ([gtarkin](https://github.com/gtarkin))
+- Darth Vader ([@vader](https://github.com/vader))
+- Governor Tarkin ([@gtarkin](https://github.com/gtarkin))
 
 
 ## v4.0.0 (1977-05-25)
@@ -85,7 +85,7 @@ exports[`createMarkdown single project outputs correct changelog 1`] = `
 * [#1](https://github.com/lerna/lerna-changelog/pull/1) feat: May the force be with you. ([@luke](https://github.com/luke))
 
 #### Committers: 1
-- Luke Skywalker ([luke](https://github.com/luke))"
+- Luke Skywalker ([@luke](https://github.com/luke))"
 `;
 
 exports[`createMarkdown single tags outputs correct changelog 1`] = `
@@ -101,7 +101,7 @@ exports[`createMarkdown single tags outputs correct changelog 1`] = `
   * [#7](https://github.com/lerna/lerna-changelog/pull/7) feat: that is not how the Force works!. ([@han-solo](https://github.com/han-solo))
 
 #### Committers: 1
-- Han Solo ([han-solo](https://github.com/han-solo))
+- Han Solo ([@han-solo](https://github.com/han-solo))
 
 
 ## v6.0.0 (1983-05-25)
@@ -123,9 +123,9 @@ exports[`createMarkdown single tags outputs correct changelog 1`] = `
   * [#4](https://github.com/lerna/lerna-changelog/pull/4) fix: RRRAARRWHHGWWR. ([@chewbacca](https://github.com/chewbacca))
 
 #### Committers: 3
-- Chwebacca ([chewbacca](https://github.com/chewbacca))
-- Darth Vader ([vader](https://github.com/vader))
-- Princess Leia Organa ([princess-leia](https://github.com/princess-leia))
+- Chwebacca ([@chewbacca](https://github.com/chewbacca))
+- Darth Vader ([@vader](https://github.com/vader))
+- Princess Leia Organa ([@princess-leia](https://github.com/princess-leia))
 
 
 ## v5.0.0 (1980-05-17)
@@ -139,8 +139,8 @@ exports[`createMarkdown single tags outputs correct changelog 1`] = `
   * [#3](https://github.com/lerna/lerna-changelog/pull/3) fix: Get me the rebels base!. ([@vader](https://github.com/vader))
 
 #### Committers: 2
-- Darth Vader ([vader](https://github.com/vader))
-- Governor Tarkin ([gtarkin](https://github.com/gtarkin))
+- Darth Vader ([@vader](https://github.com/vader))
+- Governor Tarkin ([@gtarkin](https://github.com/gtarkin))
 
 
 ## v4.0.0 (1977-05-25)
@@ -150,5 +150,5 @@ exports[`createMarkdown single tags outputs correct changelog 1`] = `
   * [#1](https://github.com/lerna/lerna-changelog/pull/1) feat: May the force be with you. ([@luke](https://github.com/luke))
 
 #### Committers: 1
-- Luke Skywalker ([luke](https://github.com/luke))"
+- Luke Skywalker ([@luke](https://github.com/luke))"
 `;

--- a/src/markdown-renderer.spec.ts
+++ b/src/markdown-renderer.spec.ts
@@ -134,7 +134,7 @@ describe("MarkdownRenderer", () => {
         html_url: "http://github.com/foo",
       });
 
-      expect(result).toEqual("[foo](http://github.com/foo)");
+      expect(result).toEqual("[@foo](http://github.com/foo)");
     });
 
     it(`renders GitHub user with name`, () => {
@@ -144,7 +144,7 @@ describe("MarkdownRenderer", () => {
         html_url: "http://github.com/foo",
       });
 
-      expect(result).toEqual("Foo Bar ([foo](http://github.com/foo))");
+      expect(result).toEqual("Foo Bar ([@foo](http://github.com/foo))");
     });
   });
 

--- a/src/markdown-renderer.ts
+++ b/src/markdown-renderer.ts
@@ -119,7 +119,7 @@ export default class MarkdownRenderer {
   }
 
   public renderContributor(contributor: GitHubUserResponse): string {
-    const userNameAndLink = `[${contributor.login}](${contributor.html_url})`;
+    const userNameAndLink = `[@${contributor.login}](${contributor.html_url})`;
     if (contributor.name) {
       return `${contributor.name} (${userNameAndLink})`;
     } else {


### PR DESCRIPTION
Previously only the list of changes had the `@` prefix, but we should be consistent and always add it to login names