### PR TITLE
Ignore dependency update bots by default

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -48,7 +48,14 @@ export function fromPath(rootPath: string, options: Partial<Configuration> = {})
   }
 
   if (!ignoreCommitters) {
-    ignoreCommitters = [];
+    ignoreCommitters = [
+      "dependabot-bot",
+      "dependabot[bot]",
+      "greenkeeperio-bot",
+      "greenkeeper[bot]",
+      "renovate-bot",
+      "renovate[bot]",
+    ];
   }
 
   return {


### PR DESCRIPTION
This PR adds the following bots to the default `ignoreCommitters` list:

- dependabot
- greenkeeper
- renovate