### PR TITLE
Improve CLI help output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ export async function run() {
       "lerna-changelog --tag-from 0.1.0 --tag-to 0.3.0",
       "create a changelog for the changes in all tags within the given range"
     )
+    .epilog("For more information, see https://github.com/lerna/lerna-changelog")
     .wrap(Math.min(100, yargs.terminalWidth()))
     .parse();
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,9 @@ import Changelog from "./changelog";
 import ConfigurationError from "./configuration-error";
 
 export async function run() {
-  const argv = require("yargs")
+  const yargs = require("yargs");
+
+  const argv = yargs
     .usage("lerna-changelog [options]")
     .options({
       "tag-from": {
@@ -25,6 +27,7 @@ export async function run() {
       "lerna-changelog --tag-from 0.1.0 --tag-to 0.3.0",
       "create a changelog for the changes in all tags within the given range"
     )
+    .wrap(Math.min(100, yargs.terminalWidth()))
     .parse();
 
   let options = {


### PR DESCRIPTION
```
lerna-changelog [options]

Optionen:
  --help      Hilfe anzeigen                                                               [boolean]
  --version   Version anzeigen                                                             [boolean]
  --tag-from  A git tag that determines the lower bound of the range of commits (defaults to last
              available)                                                                    [string]
  --tag-to    A git tag that determines the upper bound of the range of commits             [string]

Beispiele:
  lerna-changelog                                  create a changelog for the changes after the
                                                   latest available tag
  lerna-changelog --tag-from 0.1.0 --tag-to 0.3.0  create a changelog for the changes in all tags
                                                   within the given range

For more information, see https://github.com/lerna/lerna-changelog
```