### PR TITLE
flag unlabeled PRs with wildcard label

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,53 @@ The supported options are:
 
 - `labels`: GitHub PR labels mapped to changelog section headers
 
+- `wildcardLabel`: A label to identify commits that don't have a GitHub PR label 
+  which matches a value in `labels`. (e.g. `unlabeled`) By default, this has no value. [Read more about this option](#wildcardlabel).
+
 - `ignoreCommitters`: List of committers to ignore (exact or partial match).
   Useful for example to ignore commits from bots.
 
 - `cacheDir`: Path to a GitHub API response cache to avoid throttling
   (e.g. `.changelog`)
+
+### wildcardLabel
+
+For some projects, it may be beneficial to list PRs in the changelog that don't 
+have a matching label defined in the configuration `labels`. Listing these PRs also allows you to review the changelog and identify any PRs that should be re-labeled on GitHub. For example, forgetting to label a breaking change.
+
+```json5
+{
+  // ...
+  "changelog": {
+    "wildcardLabel": "unlabeled"
+  }
+}
+```
+
+A default changlog heading of `:present: Additional updates` is set when a value for `wildcardLabel` is in the configuration.
+
+```md
+## Unreleased (2018-05-24)
+
+#### 🎁 Additional updates
+* [#514](https://github.com/my-org/my-repo/pull/514) Setting to mute video ([@diligent-developer](https://github.com/diligent-developer))
+```
+
+You can overwrite the default heading by including the `wildcardLabel` value in the configuration's `labels` object. For example:
+
+```json5
+{
+  // ...
+  "changelog": {
+    "labels": {
+      "feature": "New Feature",
+      "bug": "Bug Fix",
+      "unlabeled": "Unlabeled PRs"
+    },
+    "wildcardLabel": "unlabeled"
+  }
+}
+```
 
 
 License

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -206,6 +206,18 @@ export default class Changelog {
 
       const labels = commit.githubIssue.labels.map(label => label.name.toLowerCase());
 
+      if (this.config.wildcardLabel) {
+        // check whether the commit has any of the labels from the learna.json config. 
+        // If not, label this commit with the provided label
+
+        let foundLabel = Object.keys(this.config.labels)
+        .some(label => labels.indexOf(label.toLowerCase()) !== -1);
+
+       if (!foundLabel) {
+          labels.push(this.config.wildcardLabel);
+        }
+      }
+
       commit.categories = Object.keys(this.config.labels)
         .filter(label => labels.indexOf(label.toLowerCase()) !== -1)
         .map(label => this.config.labels[label]);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -13,6 +13,7 @@ export interface Configuration {
   cacheDir?: string;
   nextVersion: string | undefined;
   nextVersionFromMetadata?: boolean;
+  wildcardLabel? : string;
 }
 
 export interface ConfigLoaderOptions {
@@ -31,7 +32,7 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
   let config = fromPackageConfig(rootPath) || fromLernaConfig(rootPath) || {};
 
   // Step 2: fill partial config with defaults
-  let { repo, nextVersion, labels, cacheDir, ignoreCommitters } = config;
+  let { repo, nextVersion, labels, cacheDir, ignoreCommitters, wildcardLabel } = config;
 
   if (!repo) {
     repo = findRepo(rootPath);
@@ -58,6 +59,10 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
     };
   }
 
+  if (wildcardLabel && !labels[wildcardLabel]) {
+    labels[wildcardLabel] = "️:present: Additional updates"
+  }
+
   if (!ignoreCommitters) {
     ignoreCommitters = [
       "dependabot-bot",
@@ -76,6 +81,7 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
     labels,
     ignoreCommitters,
     cacheDir,
+    wildcardLabel
   };
 }
 


### PR DESCRIPTION
Fixes https://github.com/lerna/lerna-changelog/issues/74

👋 Hi there, 
I'm working on a project with a distributed team and we were looking for a way to generate changelogs/releases easier. The challenge we ran up against is essentially the problem identified in https://github.com/lerna/lerna-changelog/issues/74. 

To address this, I made a change to identify any commits that didn't have a label from the config with a "wildcard label" (name taken from the linked issue).  I have details on how it works in the README.md. I wanted to share my approach to see if it is something you feel is useful before I go forward with writing test and whatnot 😃 

### Result

Example from my testing:

```json
  "changelog": {
    "labels": {
      "breaking change": "💥 Breaking Change",
      "enhancement": "🚀 Enhancement",
      "bug fix": "🐛 Bug fixes",
      "unlabeled": "🤔 Unlabeled"
    },
    "wildcardLabel": "unlabeled",
    "cacheDir": ".changelog"
  }
```

```
## Unreleased (2019-05-04)

#### 🚀 Enhancement
* [#838](https://github.com/foo/bar/pull/838) Update search results layout ([@NathanPJF](https://github.com/nathanpjf))

#### 🤔 Unlabeled
* [#903](https://github.com/foo/bar/pull/903) Unhide mute button ([@somePerson](https://github.com/somePerson))
* [#923](https://github.com/foo/bar/pull/923) Convert hardcoded values ([@somePerson](https://github.com/somePerson))
```

### Approach

I have details on my thought process [in my fork](https://github.com/NathanPJF/lerna-changelog/pull/1), but essentially I felt the following was a good workflow:

1. `wildcardLabel` is optional and by default it has no value.
2. When there is a value, a default changelog heading is provided. Figured a default heading was fine as the tool already provides a number of defaults.
3. If you want a custom heading, you need to write the same label in the configuration `labels` along with a heading.  

^ At first writing it in `labels` felt like duplication of effort. However, I realized the value for `wildcardLabel` could match a real label being used on GitHub to act as a safeguard for workflows where people are identifying PRs that need labeling. e.g. You have a typical workflow to label things on GitHub with `unlabeled` or `for triage` until you know whether the change is going to be a breaking one.  Incase that PR never gets "properly labeled" before merging, you'd want a warning in place before you make that next release.