### PR TITLE
fix: Incorrect repo parsing in configuration.ts > findRepoFromPkg method.

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -157,6 +157,7 @@ export default class Changelog {
         if (commitInfo.issueNumber) {
           commitInfo.githubIssue = await this.github.getIssueData(this.config.repo, commitInfo.issueNumber);
         }
+
         progressBar.tick();
       },
       { concurrency: 5 }

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -157,7 +157,6 @@ export default class Changelog {
         if (commitInfo.issueNumber) {
           commitInfo.githubIssue = await this.github.getIssueData(this.config.repo, commitInfo.issueNumber);
         }
-
         progressBar.tick();
       },
       { concurrency: 5 }

--- a/src/configuration.spec.ts
+++ b/src/configuration.spec.ts
@@ -65,6 +65,7 @@ describe("Configuration", function() {
       ["https://github.com/babel/ember-cli-babel", "babel/ember-cli-babel"],
       ["https://github.com/babel/ember-cli-babel.git", "babel/ember-cli-babel"],
       ["git@github.com:babel/ember-cli-babel.git", "babel/ember-cli-babel"],
+      ["https://github.com/emberjs/ember.js.git", "emberjs/ember.js"],
       ["https://gitlab.com/gnachman/iterm2.git", undefined],
       ["git@gitlab.com:gnachman/iterm2.git", undefined],
     ];

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -120,10 +120,9 @@ function findNextVersion(rootPath: string): string | undefined {
 export function findRepoFromPkg(pkg: any): string | undefined {
   const url = pkg.repository.url || pkg.repository;
   const normalized = normalize(url).url;
-  // reference https://www.debuggex.com/r/H4kRw1G0YPyBFjfm
-  const match = normalized.match(/([\/\/]?github\.com[\/:])([\w\.@\:\/\-~]+[^.git])/);
+  const match = normalized.match(/github\.com[:\/]([^\/]+\/[^\/]+?)(?:\.git)?$/);
   if (!match) {
     return;
   }
-  return match[2];
+  return match[1];
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -120,7 +120,7 @@ function findNextVersion(rootPath: string): string | undefined {
 export function findRepoFromPkg(pkg: any): string | undefined {
   const url = pkg.repository.url || pkg.repository;
   const normalized = normalize(url).url;
-  const match = normalized.match(/github\.com[:\/]([^\/]+\/[^\/]+?)(?:\.git)?$/);
+  const match = normalized.match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/);
   if (!match) {
     return;
   }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -120,7 +120,7 @@ function findNextVersion(rootPath: string): string | undefined {
 export function findRepoFromPkg(pkg: any): string | undefined {
   const url = pkg.repository.url || pkg.repository;
   const normalized = normalize(url).url;
-  //reference https://www.debuggex.com/r/H4kRw1G0YPyBFjfm
+  // reference https://www.debuggex.com/r/H4kRw1G0YPyBFjfm
   const match = normalized.match(/([\/\/]?github\.com[\/:])([\w\.@\:\/\-~]+[^.git])/);
   if (!match) {
     return;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -120,10 +120,10 @@ function findNextVersion(rootPath: string): string | undefined {
 export function findRepoFromPkg(pkg: any): string | undefined {
   const url = pkg.repository.url || pkg.repository;
   const normalized = normalize(url).url;
-  const match = normalized.match(/github\.com[:/]([^./]+\/[^./]+)(?:\.git)?/);
+  //reference https://www.debuggex.com/r/H4kRw1G0YPyBFjfm
+  const match = normalized.match(/([\/\/]?github\.com[\/:])([\w\.@\:\/\-~]+[^.git])/);
   if (!match) {
     return;
   }
-
-  return match[1];
+  return match[2];
 }


### PR DESCRIPTION
Fixes: #154 

Fix incorrect repo parsing regex. Repo Url `https://github.com/emberjs/ember.js.git` should have given `emberjs/ember.js` as the repo name instead it ended up giving `emberjs/ember` based on the regex.
