### PR TITLE
Upgrade `yargs` to v13

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "normalize-git-url": "^3.0.2",
     "p-map": "^2.1.0",
     "progress": "^2.0.0",
-    "yargs": "^11.0.0"
+    "yargs": "^13.0.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4353,13 +4353,6 @@ yargs-parser@^8.1.0:
   dependencies:
     camelcase "^4.1.0"
 
-yargs-parser@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
-  integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
-  dependencies:
-    camelcase "^4.1.0"
-
 yargs@^10.0.3:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
@@ -4378,25 +4371,7 @@ yargs@^10.0.3:
     y18n "^3.2.1"
     yargs-parser "^8.1.0"
 
-yargs@^11.0.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
-  integrity sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^1.1.1"
-    find-up "^2.1.0"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^9.0.2"
-
-yargs@^13.3.0:
+yargs@^13.0.0, yargs@^13.3.0:
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
   integrity sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==


### PR DESCRIPTION
The goal is to clean a (harmless) warning for a transitive dependency ([`mem`](https://snyk.io/vuln/npm:mem:20180117)). The fix in `yargs` is in PR #1270 (https://github.com/yargs/yargs).

This PR upgrades `yargs` from v11 to v13.

### Useful links
Here are `yargs` breaking changes for:
- v12 https://github.com/yargs/yargs/blob/master/CHANGELOG.md#breaking-changes-1
- v13 https://github.com/yargs/yargs/blob/master/CHANGELOG.md#breaking-changes