### PR TITLE
Drop support for Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: node_js
 cache: yarn
 
 node_js:
-  - '6'
   - '8'
   - '10'
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "^3.6.3"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "changelog": {
     "repo": "lerna/lerna-changelog",


### PR DESCRIPTION
... because it has reach its EOL

/cc @trivikr 