### PR TITLE
CI: Add Node.js 12 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache: yarn
 node_js:
   - '8'
   - '10'
+  - '12'
 
 script:
   - npm run test-ci


### PR DESCRIPTION
Node.js 12 moved to LTS on Oct 22, 2019
Announcement: https://medium.com/@nodejs/e28d6a4a2bd