### PR TITLE
chore: add dependabot badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@ lerna-changelog
 
 [![TravisCI Build Status][travis-badge]][travis-badge-url]
 [![Latest NPM release][npm-badge]][npm-badge-url]
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=lerna/lerna-changelog)](https://dependabot.com)
+[![Dependabot Status][dependabot-badge]][dependabot-badge-url]
 
 [npm-badge]: https://img.shields.io/npm/v/lerna-changelog.svg
 [npm-badge-url]: https://www.npmjs.com/package/lerna-changelog
 [travis-badge]: https://img.shields.io/travis/lerna/lerna-changelog/master.svg
 [travis-badge-url]: https://travis-ci.org/lerna/lerna-changelog
+[dependabot-badge]: https://api.dependabot.com/badges/status?host=github&repo=lerna/lerna-changelog
+[dependabot-badge-url]: https://dependabot.com
 
 PR-based changelog generator with monorepo support
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ lerna-changelog
 
 [![TravisCI Build Status][travis-badge]][travis-badge-url]
 [![Latest NPM release][npm-badge]][npm-badge-url]
+[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=lerna/lerna-changelog)](https://dependabot.com)
 
 [npm-badge]: https://img.shields.io/npm/v/lerna-changelog.svg
 [npm-badge-url]: https://www.npmjs.com/package/lerna-changelog


### PR DESCRIPTION
This will show dependabot status in README
![dependabot-status](https://user-images.githubusercontent.com/16024985/68623870-5538b880-048a-11ea-822f-417f7950c2f2.png)

It's inactive right now https://api.dependabot.com/badges/status?host=github&repo=lerna/lerna-changelog
Can be viewed at https://github.com/trivikr/lerna-changelog/tree/patch-1