### PR TITLE
Drop support for Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: node_js
 cache: yarn
 
 node_js:
-  - '8'
   - '10'
   - '12'
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "typescript": "^3.7.3"
   },
   "engines": {
-    "node": ">=8"
+    "node": "10.* || >= 12"
   },
   "changelog": {
     "repo": "lerna/lerna-changelog",


### PR DESCRIPTION
... because it will reach its end-of-life at the end of the month (see https://nodejs.org/en/about/releases/)