### PR TITLE
chore: remove os.tmpDir deprecation warning

### DIFF
--- a/src/configuration.spec.ts
+++ b/src/configuration.spec.ts
@@ -7,7 +7,7 @@ import ConfigurationError from "./configuration-error";
 
 describe("Configuration", function() {
   describe("fromPath", function() {
-    const tmpDir = `${os.tmpDir()}/changelog-test`;
+    const tmpDir = `${os.tmpdir()}/changelog-test`;
 
     beforeEach(function() {
       fs.ensureDirSync(tmpDir);


### PR DESCRIPTION
https://github.com/nodejs/node/blob/d3715c76b5c287d900d28f472da0186322ace811/doc/api/deprecations.md#dep0022-ostmpdir