### PR TITLE
Migrate from normalize-git-info to hosted-git-info.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "chalk": "^2.4.1",
     "cli-highlight": "^2.1.4",
     "execa": "^1.0.0",
+    "hosted-git-info": "^3.0.4",
     "make-fetch-happen": "^7.1.1",
-    "normalize-git-url": "^3.0.2",
     "p-map": "^3.0.0",
     "progress": "^2.0.0",
     "yargs": "^13.0.0"

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const execa = require("execa");
-const normalize = require("normalize-git-url");
+const hostedGitInfo = require("hosted-git-info");
 
 import ConfigurationError from "./configuration-error";
 
@@ -119,10 +119,8 @@ function findNextVersion(rootPath: string): string | undefined {
 
 export function findRepoFromPkg(pkg: any): string | undefined {
   const url = pkg.repository.url || pkg.repository;
-  const normalized = normalize(url).url;
-  const match = normalized.match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/);
-  if (!match) {
-    return;
+  const info = hostedGitInfo.fromUrl(url);
+  if (info && info.type === "github") {
+    return `${info.user}/${info.project}`;
   }
-  return match[1];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2001,6 +2001,13 @@ highlight.js@^9.6.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.10.tgz#7b18ed75c90348c045eef9ed08ca1319a2219ad2"
   integrity sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==
 
+hosted-git-info@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.4.tgz#be4973eb1fd2737b11c9c7c19380739bb249f60d"
+  integrity sha512-4oT62d2jwSDBbLLFLZE+1vPuQ1h8p9wjrJ8Mqx5TjsyWmBMV5B13eJqn8pvluqubLf3cJPTfiYCIwNwDNmzScQ==
+  dependencies:
+    lru-cache "^5.1.1"
+
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
@@ -3241,11 +3248,6 @@ node-notifier@^6.0.0:
     semver "^6.3.0"
     shellwords "^0.1.1"
     which "^1.3.1"
-
-normalize-git-url@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/normalize-git-url/-/normalize-git-url-3.0.2.tgz#8e5f14be0bdaedb73e07200310aa416c27350fc4"
-  integrity sha1-jl8Uvgva7bc+ByADEKpBbCc1D8Q=
 
 normalize-path@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
`hosted-git-info` is used by the `npm` command line client to parse repository URLs in `package.json`s. It seems to have largely replaced `normalize-git-info` (`hosted-git-info` has ~ 14m downloads weekly, vs `normalized-git-info` which has ~ 90k downloads weekly).

Migrating also removes the manual RegExp from `lerna-changelog`, which seems nice. :smile: