### PR TITLE
Omit commiters line when all are filtered out

### DIFF
--- a/src/__snapshots__/markdown-renderer.spec.ts.snap
+++ b/src/__snapshots__/markdown-renderer.spec.ts.snap
@@ -60,6 +60,16 @@ exports[`MarkdownRenderer renderContributorList renders a list of GitHub users 1
 - [@hzoo](https://github.com/hzoo)"
 `;
 
+exports[`MarkdownRenderer renderRelease includes contributors list 1`] = `
+"## v1.0.0 (2021-05-02)
+
+#### :rocket: New Feature
+* My cool PR ([@hzoo](http://hzoo.com))
+
+#### Committers: 1
+- Henry ([@hzoo](http://hzoo.com))"
+`;
+
 exports[`MarkdownRenderer renderRelease renders unreleased commits 1`] = `
 "## Unreleased (2018-07-10)
 
@@ -69,6 +79,13 @@ exports[`MarkdownRenderer renderRelease renders unreleased commits 1`] = `
 
 exports[`MarkdownRenderer renderRelease renders unreleased commits, with named next release 1`] = `
 "## v2.0.0-alpha.0 (2018-07-10)
+
+#### :rocket: New Feature
+* My cool PR ([@hzoo](http://hzoo.com))"
+`;
+
+exports[`MarkdownRenderer renderRelease skips contributors list if empty 1`] = `
+"## v1.0.0 (2021-05-02)
 
 #### :rocket: New Feature
 * My cool PR ([@hzoo](http://hzoo.com))"

--- a/src/markdown-renderer.spec.ts
+++ b/src/markdown-renderer.spec.ts
@@ -217,5 +217,43 @@ describe("MarkdownRenderer", () => {
       const result = renderer(options).renderRelease(release);
       expect(result).toMatchSnapshot();
     });
+
+    it(`includes contributors list`, () => {
+      const release: Release = {
+        name: "v1.0.0",
+        date: "2021-05-02",
+        commits: [
+          {
+            ...BASIC_COMMIT,
+            categories: [":rocket: New Feature"],
+          },
+        ],
+        contributors: [{ name: "Henry", login: "hzoo", html_url: "http://hzoo.com" }],
+      };
+      const options = {
+        categories: [":rocket: New Feature"],
+      };
+      const result = renderer(options).renderRelease(release);
+      expect(result).toMatchSnapshot();
+    });
+
+    it(`skips contributors list if empty`, () => {
+      const release: Release = {
+        name: "v1.0.0",
+        date: "2021-05-02",
+        commits: [
+          {
+            ...BASIC_COMMIT,
+            categories: [":rocket: New Feature"],
+          },
+        ],
+        contributors: [],
+      };
+      const options = {
+        categories: [":rocket: New Feature"],
+      };
+      const result = renderer(options).renderRelease(release);
+      expect(result).toMatchSnapshot();
+    });
   });
 });

--- a/src/markdown-renderer.ts
+++ b/src/markdown-renderer.ts
@@ -52,7 +52,7 @@ export default class MarkdownRenderer {
       }
     }
 
-    if (release.contributors) {
+    if (release.contributors?.length) {
       markdown += `\n\n${this.renderContributorList(release.contributors)}`;
     }
 


### PR DESCRIPTION
- do not add line about commiters to markdown when all of the contributers are filtered out in options