### PR TITLE
Add tests for github-api

### DIFF
--- a/src/__snapshots__/github-api.spec.ts.snap
+++ b/src/__snapshots__/github-api.spec.ts.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GithubAPI getIssueData get an issue data 1`] = `
+Object {
+  "labels": Array [
+    Object {
+      "name": "Type: New Feature",
+    },
+    Object {
+      "name": "Status: In Progress",
+    },
+  ],
+  "number": 2,
+  "title": "This is the commit title for the issue (#2)",
+  "user": Object {
+    "https://api.github.com/users/test-user": Object {
+      "html_url": "https://github.com/test-user",
+      "login": "test-user",
+      "name": "Test User",
+    },
+  },
+}
+`;
+
+exports[`GithubAPI getUserData get an user data 1`] = `
+Object {
+  "html_url": "https://github.com/test-user",
+  "login": "test-user",
+  "name": "Test User",
+}
+`;

--- a/src/github-api.spec.ts
+++ b/src/github-api.spec.ts
@@ -7,6 +7,21 @@ const issue = "2";
 const login = "test-user";
 
 describe("GithubAPI", () => {
+  let oldEnvVar: string | null | undefined;
+
+  beforeEach(() => {
+    oldEnvVar = "GITHUB_AUTH" in process.env ? process.env.GITHUB_AUTH : null;
+    process.env.GITHUB_AUTH = "123";
+  });
+
+  afterEach(() => {
+    if (oldEnvVar === null) {
+      delete process.env.GITHUB_AUTH;
+    } else {
+      process.env.GITHUB_AUTH = oldEnvVar;
+    }
+  });
+
   describe("getBaseIssueUrl", () => {
     it("get base issue URL", async () => {
       const github = new GithubAPI({ repo, rootPath: "" });

--- a/src/github-api.spec.ts
+++ b/src/github-api.spec.ts
@@ -1,0 +1,80 @@
+jest.mock("../src/github-api");
+jest.mock("./fetch");
+
+const MockedGithubAPI = require("./github-api").default;
+
+const repo = "lerna/lerna-changelog";
+const issue = "2";
+const login = "test-user";
+
+describe("GithubAPI", () => {
+  describe("getBaseIssueUrl", () => {
+    it("get base issue URL", async () => {
+      const github = new MockedGithubAPI({ repo, rootPath: "" });
+      const url = github.getBaseIssueUrl(repo);
+
+      expect(url).toEqual(`https://github.com/${repo}/issues/`);
+    });
+  });
+
+  describe("getIssueData", () => {
+    beforeEach(() => {
+      const issuesCache = {
+        "https://api.github.com/repos/lerna/lerna-changelog/issues/2": {
+          body: {
+            number: 2,
+            title: "This is the commit title for the issue (#2)",
+            labels: [{ name: "Type: New Feature" }, { name: "Status: In Progress" }],
+            user: {
+              "https://api.github.com/users/test-user": {
+                login: "test-user",
+                html_url: "https://github.com/test-user",
+                name: "Test User",
+              },
+            },
+          },
+        },
+      };
+      require("./fetch").__setMockResponses(issuesCache);
+    });
+
+    afterEach(() => {
+      require("./fetch").__resetMockResponses();
+      jest.resetAllMocks();
+    });
+
+    it("get an issue data", async () => {
+      const github = new MockedGithubAPI({ repo, rootPath: "" });
+      const issueData = await github.getIssueData(repo, issue);
+
+      expect(issueData).toMatchSnapshot();
+    });
+  });
+
+  describe("getUserData", () => {
+    beforeEach(() => {
+      const usersCache = {
+        "https://api.github.com/users/test-user": {
+          body: {
+            login: "test-user",
+            html_url: "https://github.com/test-user",
+            name: "Test User",
+          },
+        },
+      };
+      require("./fetch").__setMockResponses(usersCache);
+    });
+
+    afterEach(() => {
+      require("./fetch").__resetMockResponses();
+      jest.resetAllMocks();
+    });
+
+    it("get an user data", async () => {
+      const github = new MockedGithubAPI({ repo, rootPath: "" });
+      const issueData = await github.getUserData(login);
+
+      expect(issueData).toMatchSnapshot();
+    });
+  });
+});

--- a/src/github-api.spec.ts
+++ b/src/github-api.spec.ts
@@ -1,7 +1,6 @@
-jest.mock("../src/github-api");
-jest.mock("./fetch");
+import GithubAPI from "./github-api";
 
-const MockedGithubAPI = require("./github-api").default;
+jest.mock("./fetch");
 
 const repo = "lerna/lerna-changelog";
 const issue = "2";
@@ -10,7 +9,7 @@ const login = "test-user";
 describe("GithubAPI", () => {
   describe("getBaseIssueUrl", () => {
     it("get base issue URL", async () => {
-      const github = new MockedGithubAPI({ repo, rootPath: "" });
+      const github = new GithubAPI({ repo, rootPath: "" });
       const url = github.getBaseIssueUrl(repo);
 
       expect(url).toEqual(`https://github.com/${repo}/issues/`);
@@ -44,7 +43,7 @@ describe("GithubAPI", () => {
     });
 
     it("get an issue data", async () => {
-      const github = new MockedGithubAPI({ repo, rootPath: "" });
+      const github = new GithubAPI({ repo, rootPath: "" });
       const issueData = await github.getIssueData(repo, issue);
 
       expect(issueData).toMatchSnapshot();
@@ -71,7 +70,7 @@ describe("GithubAPI", () => {
     });
 
     it("get an user data", async () => {
-      const github = new MockedGithubAPI({ repo, rootPath: "" });
+      const github = new GithubAPI({ repo, rootPath: "" });
       const issueData = await github.getUserData(login);
 
       expect(issueData).toMatchSnapshot();


### PR DESCRIPTION
I was looking at how the support for Gitlab hosted could be added. And I noticed that the file github-api could benefit from more tests.