### PR TITLE
Fix handling of --next-version-from-metadata option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,8 @@ import Changelog from "./changelog";
 import { load as loadConfig } from "./configuration";
 import ConfigurationError from "./configuration-error";
 
+const NEXT_VERSION_DEFAULT = "Unreleased";
+
 export async function run() {
   const yargs = require("yargs");
 
@@ -34,7 +36,7 @@ export async function run() {
       "next-version": {
         type: "string",
         desc: "The name of the next version",
-        default: "Unreleased",
+        default: NEXT_VERSION_DEFAULT,
       },
       "next-version-from-metadata": {
         type: "boolean",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,7 +66,7 @@ export async function run() {
       nextVersionFromMetadata: argv["next-version-from-metadata"],
     });
 
-    if (argv["next-version"]) {
+    if (argv["next-version"] !== NEXT_VERSION_DEFAULT) {
       config.nextVersion = argv["next-version"];
     }
 


### PR DESCRIPTION
The `--next-version-from-metadata` option correctly reads the repo's metadata and defines `config.nextVersion` when `loadConfig` is [called](https://github.com/lerna/lerna-changelog/blob/331539b40c02f68f9c75c4f7db017977e1e62d28/src/cli.ts#L65-L67).

However, `config.nextVersion` immediately gets overridden on the next line because `argv["next-version"]` is always truthy (because it's either provided by the user or [defaults](https://github.com/lerna/lerna-changelog/blob/331539b40c02f68f9c75c4f7db017977e1e62d28/src/cli.ts#L39) to "Unreleased").

Instead, it should check if `config.nextVersion` exists and if not use `argv["next-version"]`.