### PR TITLE
Drop support for Node.js 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ["10", "12", "14", "16"]
+        node-version: ["12", "14", "16"]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "typescript": "^3.9.2"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "12.* || 14.* || >= 16"
   },
   "changelog": {
     "repo": "lerna/lerna-changelog",


### PR DESCRIPTION
Node.js 10 is no longer supported by the Node.js team.

see https://nodejs.org/en/about/releases/