### PR TITLE
CI: Update `pnpm` version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.0.1
         with:
-          version: 5.18.9
+          version: 6.12.0
 
       - run: pnpm install
       - run: pnpm build


### PR DESCRIPTION
v6 dropped support for Node.js 10. Since we've done the same we can begin using it.