### PR TITLE
Add `dependabot-preview` to default list of ignored committers

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -61,6 +61,7 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
     ignoreCommitters = [
       "dependabot-bot",
       "dependabot[bot]",
+      "dependabot-preview[bot]",
       "greenkeeperio-bot",
       "greenkeeper[bot]",
       "renovate-bot",


### PR DESCRIPTION
It's no longer active, but can still be part of the git history.