### PR TITLE
CI: Run `pnpm install` before `npm publish`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
           node-version: 14.x
           registry-url: 'https://registry.npmjs.org'
 
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6.12.0
+
+      - run: pnpm install
+
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Otherwise `tsc` won't be available...