### PR TITLE
Add support for `--repo` option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,11 @@ export async function run() {
         desc: "Infer the name of the next version from package metadata",
         default: false,
       },
+      repo: {
+        type: "string",
+        desc: "`<USER|ORG>/<PROJECT>` of the GitHub project",
+        defaultDescription: "inferred from the `package.json` file",
+      },
     })
     .example(
       "lerna-changelog",
@@ -64,6 +69,7 @@ export async function run() {
   try {
     let config = loadConfig({
       nextVersionFromMetadata: argv["next-version-from-metadata"],
+      repo: argv.repo,
     });
 
     if (argv["next-version"] !== NEXT_VERSION_DEFAULT) {

--- a/src/configuration.spec.ts
+++ b/src/configuration.spec.ts
@@ -56,6 +56,12 @@ describe("Configuration", function() {
     it("throws ConfigurationError if neither 'package.json' nor 'lerna.json' exist", function() {
       expect(() => fromPath(tmpDir)).toThrowError(ConfigurationError);
     });
+
+    it("uses passed in `repo` option", function() {
+      const result = fromPath(tmpDir, { repo: "foo/bar" });
+      expect(result.nextVersion).toEqual(undefined);
+      expect(result.repo).toEqual("foo/bar");
+    });
   });
 
   describe("findRepoFromPkg", function() {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -17,6 +17,7 @@ export interface Configuration {
 }
 
 export interface ConfigLoaderOptions {
+  repo?: string;
   nextVersionFromMetadata?: boolean;
 }
 
@@ -28,6 +29,10 @@ export function load(options: ConfigLoaderOptions = {}): Configuration {
 export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): Configuration {
   // Step 1: load partial config from `package.json` or `lerna.json`
   let config = fromPackageConfig(rootPath) || fromLernaConfig(rootPath) || {};
+
+  if (options.repo) {
+    config.repo = options.repo;
+  }
 
   // Step 2: fill partial config with defaults
   let { repo, nextVersion, labels, cacheDir, ignoreCommitters } = config;


### PR DESCRIPTION
This overrides the `repo` option in the config files and the automatic detection from the `repository` field in the `package.json` file. This allows lerna-changelog to be used outside of lerna and Node.js projects.