### PR TITLE
Update `cli-highlight` to v2.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "chalk": "^4.0.0",
-    "cli-highlight": "^2.1.4",
+    "cli-highlight": "^2.1.11",
     "execa": "^5.0.0",
     "hosted-git-info": "^4.0.0",
     "make-fetch-happen": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ specifiers:
   '@typescript-eslint/eslint-plugin': 4.33.0
   '@typescript-eslint/parser': 4.33.0
   chalk: ^4.0.0
-  cli-highlight: ^2.1.4
+  cli-highlight: ^2.1.11
   eslint: 7.32.0
   eslint-config-prettier: 8.3.0
   eslint-plugin-prettier: 4.0.0


### PR DESCRIPTION
While this version was already in the supported range, this change sets it as the minimum in order to address https://github.com/highlightjs/highlight.js/issues/2877

The older versions of cli-highlight (including 2.1.4) were still using highlight.js v9, causing consumers to receive EOL warnings when using this package. While consumers could bump the version with lockfile upgrades, this makes it explicit that we're moving away from the EOL'd versions.