### PR TITLE
Clearly mention the missing field when repository is absent

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -40,7 +40,7 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
   if (!repo) {
     repo = findRepo(rootPath);
     if (!repo) {
-      throw new ConfigurationError('Could not infer "repo" from the "package.json" file.');
+      throw new ConfigurationError('Could not infer "repository" from the "package.json" file.');
     }
   }
 


### PR DESCRIPTION
The current error message goes like:
> Could not infer "repo" from the "package.json" file.

This leads one to assume that there should be a `repo` key in the package.json.

This is a small change to make the key referred to is consistent with package.json conventions.